### PR TITLE
Add expandc2r instruction

### DIFF
--- a/docs/manual/tensor-ir.rst
+++ b/docs/manual/tensor-ir.rst
@@ -1500,6 +1500,41 @@ Further restrictions:
 * If the product of the expand shape is only known at runtime, then it is undefined behaviour
   if the dynamic product does not match the mode size.
 
+ExpandC2R
+......
+
+.. code:: abnf
+
+    value-instruction       =/ "expandc2r" local-identifier ":" memref-type
+
+Overview
+~~~~~~~~
+
+The expandc2r instruction returns a view on a tensor which has a complex element type with the complex elements reinterpreted as a new mode of size 2 and a floating element type.
+
+Operands
+~~~~~~~~
+
+The argument must point to a value of memref type with complex element type.
+
+Restrictions
+~~~~~~~~~~~~
+
+The memref type of the result must conform with the following rules:
+
+#. Element type must be the floating type corresponding to the operand's complex element type.
+#. The address space must match the operand's memref type.
+#. **Shape:** A mode of size 2 is prepended to the operand's shape.
+   The rest of the shape must be unchanged.
+
+   .. code::
+
+       expandc2r %0      : memref<f32x2x32x8>     ; %0: memref<c32x32x8>
+       expandc2r %0      : memref<f64x2x32x8>     ; %0: memref<c64x32x8>
+       expandc2r %0      : memref<f32x2x32x?>     ; %0: memref<c32x32x?>
+
+#. **Stride:** A new stride entry is entered that follows the canonical stride computation: all strides -- which are measured in units of the element type -- are multiplied by 2, and a unit stride prepended for the unrolled complex mode.
+
 For
 ...
 

--- a/include/tinytc/instructions.anko
+++ b/include/tinytc/instructions.anko
@@ -170,6 +170,11 @@ inst @expand "Expand instruction" {
     ret %result                       "result type"
 }
 
+inst @expandc2r "Expand complex-to-real instruction" {
+    op %operand                       "tensor"
+    ret %result                       "result type"
+}
+
 inst @fuse "Fuse instruction" {
     prop %from => i64 "first mode to fuse"
     prop %to   => i64 "last mode to fuse"

--- a/src/analysis/alias.cpp
+++ b/src/analysis/alias.cpp
@@ -22,6 +22,7 @@ class alias_analysis_visitor {
     void operator()(inst_view);
     void operator()(alloca_inst a);
     void operator()(expand_inst e);
+    void operator()(expandc2r_inst e);
     void operator()(fuse_inst f);
     void operator()(subview_inst s);
 
@@ -44,6 +45,13 @@ void alias_analysis_visitor::operator()(alloca_inst a) {
     }
 }
 void alias_analysis_visitor::operator()(expand_inst e) {
+    const_tinytc_value_t source = &e.operand();
+    while (alias_.find(source) != alias_.end()) {
+        source = alias_[source];
+    }
+    alias_[&e.result()] = source;
+}
+void alias_analysis_visitor::operator()(expandc2r_inst e) {
     const_tinytc_value_t source = &e.operand();
     while (alias_.find(source) != alias_.end()) {
         source = alias_[source];

--- a/src/analysis/gcd.cpp
+++ b/src/analysis/gcd.cpp
@@ -72,6 +72,7 @@ class gcd_helper {
     void operator()(cast_inst in);
     void operator()(constant_inst in);
     void operator()(expand_inst in);
+    void operator()(expandc2r_inst in);
     void operator()(for_inst in);
     void operator()(fuse_inst in);
     void operator()(load_inst in);
@@ -193,6 +194,28 @@ void gcd_helper::operator()(expand_inst in) {
         for (std::int64_t i = in.expanded_mode() + 1; i < mt->dim(); ++i) {
             shape_gcd.push_back(mi->shape_gcd(i));
             stride_gcd.push_back(mi->stride_gcd(i));
+        }
+
+        gcd_.set_memref(in.result(),
+                        memref_info(offset_gcd, std::move(shape_gcd), std::move(stride_gcd)));
+    }
+}
+void gcd_helper::operator()(expandc2r_inst in) {
+    if (auto mi = gcd_.get_memref_if(in.operand()); mi) {
+        const auto mt = get_memref_type(in.operand());
+        const auto offset_gcd = mi->offset_gcd();
+        auto shape_gcd = std::vector<std::int64_t>{};
+        auto stride_gcd = std::vector<std::int64_t>{};
+
+        shape_gcd.reserve(mt->dim() + 1);
+        stride_gcd.reserve(mt->dim() + 1);
+
+        shape_gcd.push_back(2);
+        stride_gcd.push_back(1);
+
+        for (std::int64_t i = 0; i < mt->dim(); ++i) {
+            shape_gcd.push_back(mi->shape_gcd(i));
+            stride_gcd.push_back(2 * mi->stride_gcd(i));
         }
 
         gcd_.set_memref(in.result(),

--- a/src/node/inst_view_impl.cpp
+++ b/src/node/inst_view_impl.cpp
@@ -479,6 +479,45 @@ void expand_inst::setup_and_check() {
     }
 }
 
+void expandc2r_inst::setup_and_check() {
+    auto ty = result().ty();
+
+    auto rt = dyn_cast<memref_type>(ty);
+    if (!rt) {
+        throw compilation_error(loc(), status::ir_expected_memref);
+    }
+    auto ot = get_memref_type(loc(), operand());
+    if (!isa<complex_type>(*ot->element_ty()) ||
+        rt->element_ty() != component_type(ot->element_ty())) {
+        throw compilation_error(loc(), {&operand()}, status::ir_number_mismatch);
+    }
+    if (rt->addrspace() != ot->addrspace()) {
+        throw compilation_error(loc(), {&operand()}, status::ir_address_space_mismatch);
+    }
+
+    if (rt->dim() != ot->dim() + 1 || rt->shape(0) != 2) {
+        throw compilation_error(loc(), {&operand()}, status::ir_incompatible_shapes);
+    }
+
+    if (rt->stride(0) != 1) {
+        auto extra_info = std::ostringstream{} << "Stride of return mode 0 is " << rt->stride(0)
+                                               << ", must be 1";
+        throw compilation_error(loc(), status::ir_invalid_stride, std::move(extra_info).str());
+    }
+
+    for (std::int64_t i = 0; i < ot->dim(); ++i) {
+        check_memref_shape(rt, i + 1, ot, i, loc());
+
+        if (!is_dynamic_value(rt->stride(i + 1)) && rt->stride(i + 1) != 2 * ot->stride(i)) {
+            auto extra_info = std::ostringstream{}
+                              << "Stride of mode " << i + 1
+                              << " does not equal two times the operand stride " << i << " ["
+                              << rt->stride(i + 1) << "!= 2x" << ot->stride(i) << "]";
+            throw compilation_error(loc(), status::ir_invalid_stride, std::move(extra_info).str());
+        }
+    }
+}
+
 void fuse_inst::setup_and_check() {
     auto ty = result().ty();
     auto [ot, rt] = get_and_check_memref_type_addrspace(operand(), ty, loc());

--- a/src/parser/lexer.re
+++ b/src/parser/lexer.re
@@ -213,6 +213,7 @@ lex:
         "cooperative_matrix_scale"        { adv_loc(); return parser::make_COOPERATIVE_MATRIX_SCALE(loc_); }
         "cooperative_matrix_store"        { adv_loc(); return parser::make_COOPERATIVE_MATRIX_STORE(loc_); }
         "expand"             { adv_loc(); return parser::make_EXPAND(loc_); }
+        "expandc2r"          { adv_loc(); return parser::make_EXPANDC2R(loc_); }
         "fuse"               { adv_loc(); return parser::make_FUSE(loc_); }
         "load"               { adv_loc(); return parser::make_LOAD(loc_); }
         "for"                { adv_loc(); return parser::make_FOR(loc_); }

--- a/src/parser/parser_impl.yy
+++ b/src/parser/parser_impl.yy
@@ -179,6 +179,7 @@
     COOPERATIVE_MATRIX_SCALE        "cooperative_matrix_scale"
     COOPERATIVE_MATRIX_STORE        "cooperative_matrix_store"
     EXPAND                          "expand"
+    EXPANDC2R                       "expandc2r"
     FUSE                            "fuse"
     LOAD                            "load"
     IF                              "if"
@@ -1156,6 +1157,14 @@ integer_constant_or_identifier:
     }
   | integer_constant_or_def {
         $$ = $integer_constant_or_def;
+    }
+;
+
+valued_inst:
+    EXPANDC2R var COLON data_type[ty] {
+        yytry(ctx, [&] {
+            $$ = expandc2r_inst::create(std::move($var), $ty, @valued_inst);
+        });
     }
 ;
 

--- a/src/pass/dump_ir.cpp
+++ b/src/pass/dump_ir.cpp
@@ -517,6 +517,14 @@ void dump_ir_pass::operator()(expand_inst e) {
     visit(*this, *e.result().ty());
 }
 
+void dump_ir_pass::operator()(expandc2r_inst e) {
+    dump_val(e.result());
+    *os_ << " = expandc2r ";
+    dump_val(e.operand());
+    *os_ << " : ";
+    visit(*this, *e.result().ty());
+}
+
 void dump_ir_pass::operator()(fuse_inst f) {
     dump_val(f.result());
     *os_ << " = fuse ";

--- a/src/pass/dump_ir.hpp
+++ b/src/pass/dump_ir.hpp
@@ -65,6 +65,7 @@ class dump_ir_pass {
     void operator()(cooperative_matrix_store_inst c);
     void operator()(cumsum_inst a);
     void operator()(expand_inst e);
+    void operator()(expandc2r_inst e);
     void operator()(fuse_inst f);
     void operator()(load_inst l);
     void operator()(lifetime_stop_inst l);

--- a/src/spv/converter.cpp
+++ b/src/spv/converter.cpp
@@ -571,6 +571,56 @@ void inst_converter::operator()(expand_inst in) {
     }
 }
 
+void inst_converter::operator()(expandc2r_inst in) {
+    auto spv_index_ty = get_spv_index_ty(unique_, in.operand().context());
+
+    auto const make_shape_stride =
+        [&]() -> std::pair<std::vector<spv_inst *>, std::vector<spv_inst *>> {
+        auto sshape = std::vector<spv_inst *>{};
+        auto sstride = std::vector<spv_inst *>{};
+
+        auto dv = get_dope_vector(in.operand());
+        auto mt = get_memref_type(in.operand());
+        if (!dv) {
+            throw compilation_error(in.loc(), status::spirv_missing_dope_vector);
+        }
+
+        sshape.reserve(mt->dim() + 1);
+        sstride.reserve(mt->dim() + 1);
+
+        sshape.push_back(unique_.index_constant(2));
+        sstride.push_back(unique_.index_constant(1));
+
+        for (std::int64_t i = 0; i < mt->dim(); ++i) {
+            sshape.push_back(dv->shape(i));
+            sstride.push_back(
+                mod_->add<OpIMul>(spv_index_ty, unique_.index_constant(2), dv->stride(i)));
+        }
+
+        return {sshape, sstride};
+    };
+
+    auto [shape, stride] = make_shape_stride();
+
+    auto ov = val(in.operand());
+    auto to_ty = in.result().ty();
+    auto o_ty = in.operand().ty();
+    declare(in.result(), make_bitcast_nosizecheck(unique_, to_ty, o_ty, ov));
+
+    auto rdv = make_dope_vector(in.result());
+
+    if (shape.size() != static_cast<std::size_t>(rdv->dim()) ||
+        stride.size() != static_cast<std::size_t>(rdv->dim())) {
+        throw compilation_error(in.loc(), status::internal_compiler_error);
+    }
+    for (std::int64_t i = 0; i < rdv->dim(); ++i) {
+        rdv->shape(i, shape[i]);
+    }
+    for (std::int64_t i = 0; i < rdv->dim(); ++i) {
+        rdv->stride(i, stride[i]);
+    }
+}
+
 void inst_converter::operator()(for_inst in) {
     auto header_label_op = std::make_unique<OpLabel>();
     auto body_label_op = std::make_unique<OpLabel>();
@@ -1174,4 +1224,3 @@ void inst_converter::run_on_function(tinytc_func &fn) {
 }
 
 } // namespace tinytc::spv
-

--- a/src/spv/converter.hpp
+++ b/src/spv/converter.hpp
@@ -59,6 +59,7 @@ class inst_converter {
     void operator()(cooperative_matrix_scale_inst in);
     void operator()(cooperative_matrix_store_inst in);
     void operator()(expand_inst in);
+    void operator()(expandc2r_inst in);
     void operator()(for_inst in);
     void operator()(fuse_inst in);
     void operator()(if_inst in);

--- a/src/spv/converter_aux.cpp
+++ b/src/spv/converter_aux.cpp
@@ -301,13 +301,9 @@ auto make_binary_op_mixed_precision(uniquifier &unique, tinytc_type_t result_ty,
     return make_binary_op(unique, result_ty, op, a, b, loc);
 }
 
-auto make_bitcast(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty, spv_inst *a,
-                  location const &loc) -> spv_inst * {
+auto make_bitcast_nosizecheck(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty,
+                              spv_inst *a) -> spv_inst * {
     auto &mod = unique.mod();
-
-    if (size(a_ty) != size(to_ty)) {
-        throw compilation_error(loc, status::ir_forbidden_cast);
-    }
 
     auto spv_a_ty = get_spv_ty_non_coopmatrix(unique, a_ty);
     auto spv_to_ty = get_spv_ty_non_coopmatrix(unique, to_ty);
@@ -315,6 +311,15 @@ auto make_bitcast(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty, s
         return mod.add<OpCopyObject>(spv_to_ty, a);
     }
     return mod.add<OpBitcast>(spv_to_ty, a);
+}
+
+auto make_bitcast(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty, spv_inst *a,
+                  location const &loc) -> spv_inst * {
+    if (size(a_ty) != size(to_ty)) {
+        throw compilation_error(loc, status::ir_forbidden_cast);
+    }
+
+    return make_bitcast_nosizecheck(unique, to_ty, a_ty, a);
 }
 
 auto make_cast(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty, spv_inst *a,
@@ -922,4 +927,3 @@ auto make_subgroup_op(uniquifier &unique, tinytc_type_t op_ty, IK op, spv_inst *
 }
 
 } // namespace tinytc::spv
-

--- a/src/spv/converter_aux.hpp
+++ b/src/spv/converter_aux.hpp
@@ -44,6 +44,8 @@ auto make_binary_op(uniquifier &unique, tinytc_type_t operand_ty, IK op, spv_ins
 auto make_binary_op_mixed_precision(uniquifier &unique, tinytc_type_t result_ty, IK op,
                                     tinytc_type_t a_ty, spv_inst *a, tinytc_type_t b_ty,
                                     spv_inst *b, location const &loc) -> spv_inst *;
+auto make_bitcast_nosizecheck(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty,
+                              spv_inst *a) -> spv_inst *;
 auto make_bitcast(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty, spv_inst *a,
                   location const &loc) -> spv_inst *;
 auto make_cast(uniquifier &unique, tinytc_type_t to_ty, tinytc_type_t a_ty, spv_inst *a,

--- a/src/spv/uniquifier.cpp
+++ b/src/spv/uniquifier.cpp
@@ -47,6 +47,12 @@ auto uniquifier::bool_constant(bool b) -> spv_inst * {
     });
 }
 
+auto uniquifier::index_constant(std::int64_t i) -> spv_inst * {
+    if (mod().context()->index_bit_width() == 32)
+        return constant(std::int32_t(i));
+    return constant(i);
+}
+
 auto uniquifier::builtin_alignment(BuiltIn b) -> std::int32_t {
     switch (b) {
     case BuiltIn::WorkDim:
@@ -253,4 +259,3 @@ auto uniquifier::load_builtin(BuiltIn b) -> spv_inst * {
 }
 
 } // namespace tinytc::spv
-

--- a/src/spv/uniquifier.hpp
+++ b/src/spv/uniquifier.hpp
@@ -35,6 +35,7 @@ class uniquifier {
 
     auto asm_target() -> spv_inst *;
     auto bool_constant(bool b) -> spv_inst *;
+    auto index_constant(std::int64_t i) -> spv_inst *;
     auto builtin_alignment(BuiltIn b) -> std::int32_t;
     auto builtin_pointee_ty(BuiltIn b) -> spv_inst *;
     auto builtin_var(BuiltIn b) -> spv_inst *;

--- a/test/lit/opt/check-ir/expandc2r.ir
+++ b/test/lit/opt/check-ir/expandc2r.ir
@@ -1,0 +1,20 @@
+; Copyright (C) 2024 Intel Corporation
+; SPDX-License-Identifier: BSD-3-Clause
+
+; RUN: %tinytc-opt -pcheck-ir -O0 < %s | filecheck %s
+
+; No real checks needed, just check that it does not crash
+; CHECK: func @t1({{.*}}
+
+func @t1(%0: memref<c32x32x16x8>) {
+  %1 = expandc2r %0 : memref<f32x2x32x16x8>
+}
+func @t2(%0: memref<c64x32x16x8>) {
+  %1 = expandc2r %0 : memref<f64x2x32x16x8>
+}
+func @t3(%0: memref<c32x32x?>) {
+  %1 = expandc2r %0 : memref<f32x2x32x?>
+}
+func @t4(%0: memref<c32x32x?>) {
+  %1 = expandc2r %0 : memref<f32x2x32x?>
+}

--- a/test/lit/opt/memref-info.ir
+++ b/test/lit/opt/memref-info.ir
@@ -25,6 +25,18 @@ func @expand(%a: memref<i8x64>, %b: memref<i8x?x?> {shape_gcd=[16,3], stride_gcd
 ; CHECK:       stride_gcd(%3) = [1,4,16]
 }
 
+func @expandc2r(%a: memref<c32x64x16>, %b: memref<c32x16x?> {shape_gcd=[16,8], stride_gcd=[1,4]}) {
+    %0 = expandc2r %a : memref<f32x2x64x16>
+    %1 = expandc2r %b : memref<f32x2x16x?,strided<1,2,32>>
+; CHECK-LABEL: GCD in @expandc2r
+; CHECK:       offset_gcd(%0) = 16
+; CHECK:       shape_gcd(%0) = [2,64,16]
+; CHECK:       stride_gcd(%0) = [1,2,128]
+; CHECK:       offset_gcd(%1) = 16
+; CHECK:       shape_gcd(%1) = [2,16,8]
+; CHECK:       stride_gcd(%1) = [1,2,8]
+}
+
 func @fuse(%a: memref<i8x8x8>, %b: memref<i8x?x?x?> {shape_gcd=[4,4,42], stride_gcd=[1,4,16]}) {
     %0 = fuse %a[0,1] : memref<i8x64>
     %1 = fuse %b[0,1] : memref<i8x?x?>

--- a/test/lit/spv/expandc2r.ir
+++ b/test/lit/spv/expandc2r.ir
@@ -1,0 +1,35 @@
+; Copyright (C) 2024 Intel Corporation
+; SPDX-License-Identifier: BSD-3-Clause
+
+; RUN: %tinytc-oc -O0 -S < %s | filecheck %s
+
+; CHECK:  %[[#F32:]] = OpTypeFloat 32
+; CHECK:  %[[#C32:]] = OpTypeVector %[[#F32]]
+; CHECK:  %[[#I64:]] = OpTypeInt 64 0
+; CHECK:  %[[#I64_C32:]] = OpConstant %[[#I64]] 32
+; CHECK:  %[[#I64_C1:]] = OpConstant %[[#I64]] 1
+; CHECK:  %[[#I64_C0:]] = OpConstant %[[#I64]] 0
+; CHECK:  %[[#I64_C2:]] = OpConstant %[[#I64]] 2
+
+func @f1(%0: memref<c32x32x?>) {
+  %c0 = constant 0 : index
+  %1 = expandc2r %0 : memref<f32x2x32x?>
+  %2 = size %1[0] : index
+  %3 = size %1[1] : index
+  %4 = size %1[2] : index
+  %5 = not %2 : index
+  %6 = not %3 : index
+  %7 = not %4 : index
+  %8 = load %1[%c0,%c0,%c0] : f32
+; CHECK:                %[[#]] = OpFunction {{.*}}
+; CHECK-NEXT:      %[[#P_MR:]] = OpFunctionParameter %[[#]]
+; CHECK-NEXT:  %[[#PSHAPE1:]] = OpFunctionParameter %[[#I64]]
+; CHECK:       %[[#ESTRIDE1:]] = OpIMul %[[#I64]] %[[#I64_C2]] %[[#I64_C1]]
+; CHECK-NEXT:  %[[#ESTRIDE2:]] = OpIMul %[[#I64]] %[[#I64_C2]] %[[#I64_C32]]
+; CHECK-NEXT:           %[[#]] = OpBitcast {{.*}} %[[#P_MR]]
+; CHECK-NEXT:           %[[#]] = OpNot %[[#I64]] %[[#I64_C2]]
+; CHECK-NEXT:           %[[#]] = OpNot %[[#I64]] %[[#I64_C32]]
+; CHECK-NEXT:           %[[#]] = OpNot %[[#I64]] %[[#PSHAPE1]]
+; CHECK:                %[[#]] = OpIMul %[[#I64]] %[[#I64_C0]] %[[#ESTRIDE1]]
+; CHECK:                %[[#]] = OpIMul %[[#I64]] %[[#I64_C0]] %[[#ESTRIDE2]]
+}


### PR DESCRIPTION
Add instruction to reinterpret the real and imaginary numbers of a complex tensor as an additional mode with size 2 on a real tensor. See specification for usage.